### PR TITLE
Fix TRIGGER and SEQUENCE warnings

### DIFF
--- a/lib/src/model/icalendar.dart
+++ b/lib/src/model/icalendar.dart
@@ -122,7 +122,7 @@ class ICalendar {
     'DTSTART': _generateDateFunction('dtstart'),
     'DTEND': _generateDateFunction('dtend'),
     'DTSTAMP': _generateDateFunction('dtstamp'),
-    'TRIGGER': _generateDateFunction('trigger'),
+    'TRIGGER': _generateSimpleParamFunction('trigger'),
     'LAST-MODIFIED': _generateDateFunction('lastModified'),
     'COMPLETED': _generateDateFunction('completed'),
     'DUE': _generateDateFunction('due'),
@@ -184,7 +184,7 @@ class ICalendar {
       lastEvent['status'] = value.trim().toIcsStatus();
       return lastEvent;
     },
-    'SEQUENCE': _generateDateFunction('sequence'),
+    'SEQUENCE': _generateSimpleParamFunction('sequence'),
     'REPEAT': _generateSimpleParamFunction('repeat'),
     'CLASS': _generateSimpleParamFunction('class'),
     'TRANSP': (String value, Map<String, String> _, List __,

--- a/test/parsing_test.dart
+++ b/test/parsing_test.dart
@@ -79,7 +79,6 @@ void main() {
         () async {
       final eventText = readFileLines('american_history.ics');
       final iCalParsed = ICalendar.fromLines(eventText);
-      print(iCalParsed.data?[2]['location']);
       expect(
         iCalParsed.data?[2]['url'],
         equals('https://americanhistorycalendar.com/eventscalendar/2,1853-emancipation-proclamation')


### PR DESCRIPTION
The SEQUENCE property [should be an int](https://www.kanzaki.com/docs/ical/sequence.html), but is currently parsed as a date string which triggers the warning `Warning: 0 could not be parsed, stored as String`.

The TRIGGER property [normally is a duration type](https://www.kanzaki.com/docs/ical/trigger.html). These warnings looks like this: `-PT15H could not be parsed, stored as String`.