### PR TITLE
Export ics_datetime.dart

### DIFF
--- a/lib/icalendar_parser.dart
+++ b/lib/icalendar_parser.dart
@@ -2,5 +2,6 @@ library icalendar_parser;
 
 export 'src/exceptions/icalendar_exception.dart';
 export 'src/model/icalendar.dart';
+export 'src/model/ics_datetime.dart';
 export 'src/model/ics_status.dart';
 export 'src/model/ics_transp.dart';


### PR DESCRIPTION
By exporting `IcsDateTime`, it gets included in documentation and users can use it as a type in their code. It also allows IDEs to auto-complete code such as `icsDateTime.toDateTime()`.